### PR TITLE
Fix custom password and add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,40 @@ The backend is built on top of [Ergo Explorer](https://github.com/ergoplatform/e
  - ErgoWatch relations are exposed through a FastAPI layer.
 
 Frontend: see https://github.com/abchrisxyz/ergowatch-ui
+
+## Installation
+
+```bash
+git clone https://github.com/abchrisxyz/ergowatch
+cd ergowatch
+
+# install grabber
+./build.sh
+
+# create Postgres database password file
+touch ./explorer-backend/db/db.secret
+
+# update newly created Postgress database password file with:
+POSTGRES_PASSWORD=your-database-password
+
+# Create  external docker volume for ergowatch
+docker volume create ew_node
+
+# Build and run the docker environement
+docker-compose -f docker-compose.yml up -d --build
+```
+
+> Please note that you might see errors in your docker logs but these will automatically
+> disappear once your node has reached a `height` value. To check height status, 
+> browse to either
+> [http://localhost:9053/info](http://localhost:9053/info)
+> or 
+> [http://localhost:9053/panel](http://localhost:9053/panel).
+
+## Database
+
+Connect using any PostgreSQL client and specifying:
+
+- database `ergo`
+- port `5433`
+- the password you configured earlier

--- a/api/src/main/db.py
+++ b/api/src/main/db.py
@@ -8,9 +8,8 @@ CONNECTION_POOL = None
 
 async def init_connection_pool():
     global CONNECTION_POOL
-    dbstr = f"postgresql://{os.environ['POSTGRES_PASSWORD']}:ergo@db/ergo"
+    dbstr = f"postgresql://ergo:{os.environ['POSTGRES_PASSWORD']}@db/ergo"
     CONNECTION_POOL = await asyncpg.create_pool(dbstr)
-
 
 async def get_latest_block_height():
     qry = "SELECT MAX(height) AS height FROM node_headers;"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,9 @@ services:
     build:
       context: ./explorer-backend/9.4.3
       dockerfile: chain-grabber.Dockerfile
+    env_file:
+      # Defines POSTGRES_PASSWORD
+      - ./explorer-backend/db/db.secret
     volumes:
       - ./explorer-backend/conf/explorer-backend.conf:/explorer-backend.conf:ro
     command: /explorer-backend.conf

--- a/explorer-backend/conf/explorer-backend.conf
+++ b/explorer-backend/conf/explorer-backend.conf
@@ -8,7 +8,7 @@ network {
 
 db.url = "jdbc:postgresql://db:5432/ergo"
 db.user = "ergo"
-db.pass = "ergo"
+db.pass = ${?POSTGRES_PASSWORD}
 db.cp-size = 8
 # redis.url = "redis://ergo-redis:6379"
 

--- a/syncer/src/main.py
+++ b/syncer/src/main.py
@@ -24,7 +24,7 @@ except KeyError as e:
     logger.error(f"Environment variable {e} is not set")
     exit(1)
 
-DBSTR = f"postgresql://{DB_PASS}:{DB_USER}@{DB_HOST}/{DB_NAME}"
+DBSTR = f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}/{DB_NAME}"
 
 # Node heights queue
 Q = asyncio.Queue()


### PR DESCRIPTION
After merging this PR, the `POSTGRES_PASSWORD` in `db.secret` is actually used inside all containers.

Adds installation instructions as a bonus.